### PR TITLE
Correct argument type in Shop.update/1

### DIFF
--- a/lib/banyan_api/shop.ex
+++ b/lib/banyan_api/shop.ex
@@ -23,7 +23,7 @@ defmodule BanyanAPI.Shop do
     "zip" => ""
   }
 
-  @spec update(%{access_token: String.t(), settings: map()}) ::
+  @spec update(%{access_token: String.t(), settings: map(), created_date: DateTime.t()}) ::
           {:ok, %Neuron.Response{}} | {:error, any()}
   def update(%{
         access_token: token,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BanyanAPI.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.9.1"
 
   def project do
     [


### PR DESCRIPTION
This change updates Shop.update/1 typespec to reflect its implementation. The function requires its callers to provide a map the `created_date` field.